### PR TITLE
1.20 and 1.20.1 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.11-SNAPSHOT'
+	id 'fabric-loom' version '1.2-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.20
-	yarn_mappings=1.20+build.1
 	loader_version=0.14.21
 
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.20.1
-	yarn_mappings=1.20.1+build.5
+	minecraft_version=1.20
+	yarn_mappings=1.20+build.1
 	loader_version=0.14.21
 
 # Mod Properties
-	mod_version = 1.3.2
+	mod_version = 1.3.3
 	maven_group = com.trufflez
 	archives_base_name = skiptransitions
 
 # Dependencies
-	fabric_version=0.84.0+1.20.1
+	fabric_version=0.83.0+1.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.18.2
-	loader_version=0.13.3
+	minecraft_version=1.20.1
+	yarn_mappings=1.20.1+build.5
+	loader_version=0.14.21
 
 # Mod Properties
 	mod_version = 1.3.2
@@ -12,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = skiptransitions
 
 # Dependencies
-	fabric_version=0.48.0+1.18.2
+	fabric_version=0.84.0+1.20.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,9 +24,9 @@
     "skiptransitions.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.13.3",
-    "fabric": "*",
-    "minecraft": ">=1.18",
+    "fabricloader": ">=0.14.21",
+    "fabric": ">=0.83.0+1.20",
+    "minecraft": ">=1.20",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
This PR only updates dependencies and tools, since that's the only requirement for the mod to work on Minecraft 1.20 and later.
Bumps mod version: (1.3.2 -> 1.3.3)

## Dependency and tool updates:
Gradle (7.4 -> 8.1.1)
Fabric Loom (0.11 -> 1.2)
Fabric API (0.48.0+1.18.2 -> 0.83.0+1.20)
Minecraft (1.18.2 -> 1.20)

## Closes

Closes: https://github.com/trufflezmc/skip-transitions/issues/8, since this mod already works on 1.19.3
Closes: https://github.com/trufflezmc/skip-transitions/issues/9